### PR TITLE
Add sparepart catalog and online service booking with payment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Website profesional untuk Bengkel Motor Rogodono di Desa Rogodono, Kecamatan Buayan, Kebumen. Situs ini berisi profil bengkel, layanan, galeri, testimoni pelanggan, FAQ, alamat, serta formulir kontak.
 
+Tambahan fitur:
+
+- Daftar sparepart beserta harga.
+- Formulir servis panggilan online dengan perhitungan biaya perjalanan Rp10.000/km.
+- Informasi metode pembayaran (tunai, transfer bank, dan e-wallet).
+
 ## Cara Menjalankan
 
 Buka file `index.html` di peramban favorit Anda.

--- a/index.html
+++ b/index.html
@@ -18,9 +18,12 @@
           <li><a href="#beranda">Beranda</a></li>
           <li><a href="#tentang">Tentang</a></li>
           <li><a href="#layanan">Layanan</a></li>
+          <li><a href="#sparepart">Sparepart</a></li>
+          <li><a href="#panggilan">Servis Panggilan</a></li>
           <li><a href="#galeri">Galeri</a></li>
           <li><a href="#testimoni">Testimoni</a></li>
           <li><a href="#faq">FAQ</a></li>
+          <li><a href="#pembayaran">Pembayaran</a></li>
           <li><a href="#kontak">Kontak</a></li>
         </ul>
       </nav>
@@ -55,6 +58,70 @@
         <li>Penggantian suku cadang</li>
         <li>Cuci motor</li>
       </ul>
+    </section>
+
+    <section id="sparepart">
+      <h2>Sparepart</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Nama</th>
+            <th>Harga</th>
+            <th>Keterangan</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Busi</td>
+            <td>Rp20.000</td>
+            <td>Busi standar untuk berbagai tipe motor</td>
+          </tr>
+          <tr>
+            <td>Oli Mesin 1L</td>
+            <td>Rp45.000</td>
+            <td>Oli sintetik SAE 10W-40</td>
+          </tr>
+          <tr>
+            <td>Kampas Rem</td>
+            <td>Rp35.000</td>
+            <td>Kampas rem belakang</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="panggilan">
+      <h2>Servis Panggilan Online</h2>
+      <p>
+        Isi formulir berikut untuk memesan servis panggilan. Biaya perjalanan
+        Rp10.000 per km.
+      </p>
+      <form id="service-form">
+        <label>Nama:<br /><input type="text" name="nama" required /></label>
+        <label>Alamat:<br /><input type="text" name="alamat" required /></label>
+        <label>
+          Jarak dari bengkel (km):<br />
+          <input type="number" id="jarak" name="jarak" min="0" step="0.1" required />
+        </label>
+        <p id="biaya-perjalanan">Biaya perjalanan: Rp0</p>
+        <label>
+          Layanan:<br />
+          <select name="layanan">
+            <option>Servis rutin</option>
+            <option>Ganti oli</option>
+            <option>Perbaikan mesin</option>
+          </select>
+        </label>
+        <label>
+          Metode Pembayaran:<br />
+          <select name="pembayaran">
+            <option>Tunai</option>
+            <option>Transfer Bank</option>
+            <option>E-Wallet</option>
+          </select>
+        </label>
+        <button type="submit">Kirim Permintaan</button>
+      </form>
     </section>
 
     <section id="galeri">
@@ -101,6 +168,28 @@
         <summary>Apakah menerima servis panggilan?</summary>
         <p>Ya, kami menyediakan layanan servis panggilan dalam radius 10 km.</p>
       </details>
+    </section>
+
+    <section id="pembayaran">
+      <h2>Metode Pembayaran</h2>
+      <ul>
+        <li>Tunai di bengkel atau saat servis panggilan</li>
+        <li>
+          Transfer Bank:
+          <ul>
+            <li>BCA 123456789 a.n. Bengkel Rogodono</li>
+            <li>Mandiri 987654321 a.n. Bengkel Rogodono</li>
+          </ul>
+        </li>
+        <li>
+          E-Wallet:
+          <ul>
+            <li>OVO 0812-3456-789</li>
+            <li>GoPay 0812-3456-789</li>
+            <li>Dana 0812-3456-789</li>
+          </ul>
+        </li>
+      </ul>
     </section>
 
     <section id="kontak">

--- a/script.js
+++ b/script.js
@@ -6,6 +6,27 @@ document
     this.reset();
   });
 
+const jarakInput = document.getElementById("jarak");
+if (jarakInput) {
+  jarakInput.addEventListener("input", function () {
+    const jarak = parseFloat(this.value) || 0;
+    const biaya = jarak * 10000;
+    document.getElementById("biaya-perjalanan").textContent =
+      `Biaya perjalanan: Rp${biaya.toLocaleString("id-ID")}`;
+  });
+}
+
+const serviceForm = document.getElementById("service-form");
+if (serviceForm) {
+  serviceForm.addEventListener("submit", function (e) {
+    e.preventDefault();
+    alert("Permintaan servis telah dikirim! Kami akan segera menghubungi Anda.");
+    this.reset();
+    document.getElementById("biaya-perjalanan").textContent =
+      "Biaya perjalanan: Rp0";
+  });
+}
+
 // Smooth scroll untuk navigasi anchor
 document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
   anchor.addEventListener("click", function (e) {

--- a/style.css
+++ b/style.css
@@ -43,6 +43,19 @@ ul {
   padding-left: 1.2rem;
 }
 
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+table th,
+table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}
+
 form {
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- add sparepart section and online service booking with distance-based travel cost
- detail payment methods including bank transfer and e-wallet options
- style tables and compute travel cost in the service form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689762ca8d148327abf0306146c5cb5f